### PR TITLE
zero: wpa_supplicant(hidl): Add support for

### DIFF
--- a/ramdisk/init.wifi.rc
+++ b/ramdisk/init.wifi.rc
@@ -74,11 +74,14 @@ on boot
 	write /sys/class/net/wlan0/queues/rx-0/rps_cpus 00
 
 service wpa_supplicant /vendor/bin/hw/wpa_supplicant -dd \
-        -iwlan0 -Dnl80211 -c/data/vendor/wifi/wpa/wpa_supplicant.conf \
-        -I/vendor/etc/wifi/wpa_supplicant_overlay.conf \
         -O/data/vendor/wifi/wpa/sockets \
-        -e/data/vendor/wifi/wpa/entropy.bin \
         -g@android:wpa_wlan0
+    # we will start as root and wpa_supplicant will switch to user wifi
+    # after setting up the capabilities required for WEXT
+    # user wifi
+    # group wifi inet keystore
+    interface android.hardware.wifi.supplicant@1.0::ISupplicant default
+    interface android.hardware.wifi.supplicant@1.1::ISupplicant default
     class main
     socket wpa_wlan0 dgram 660 wifi wifi
     disabled


### PR DESCRIPTION
 starting  HAL lazily

Bug: 72394251
Test: Able to start supplicant from framework using
ISupplicant.getService()
Change-Id: I19b8434e7241b9028e7dc86316ec9d5512affcca